### PR TITLE
[#64] 데스크탑 navbar 사이드바 이동

### DIFF
--- a/front/src/components/NavBar.vue
+++ b/front/src/components/NavBar.vue
@@ -1,16 +1,19 @@
 <template>
     <template v-if="showNavBar">
-        <router-link :to="{ name: 'momo/edit' }"
-            class="fixed bottom-[85px] left-1/2 -translate-x-1/2 w-[56px] h-[56px] bg-emerald-500 rounded-full flex justify-center items-center text-white shadow-[0_4px_10px_rgba(16,185,129,0.3)] z-[110] transition-transform duration-300 hover:scale-110 active:scale-95">
-            <i class="fas fa-plus text-[24px]"></i>
-        </router-link>
         <nav
-            class="fixed bottom-0 w-full max-w-[480px] h-[65px] bg-white flex justify-around items-center border-t border-slate-100 z-[100] left-1/2 -translate-x-1/2">
+            class="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[480px] h-[65px] bg-white flex justify-around items-center border-t border-slate-100 z-[100]
+                   md:top-1/2 md:-translate-y-1/2 md:bottom-auto md:left-[calc(50%+260px)] md:translate-x-0 md:w-[80px] md:max-w-none md:h-auto md:py-8 md:flex-col md:justify-center md:gap-y-10 md:border-none md:rounded-[32px] md:shadow-[0_10px_40px_rgba(0,0,0,0.06)]">
+
+            <router-link :to="{ name: 'momo/edit' }" class="absolute bottom-[85px] left-1/2 -translate-x-1/2 w-[56px] h-[56px] bg-emerald-500 rounded-full flex justify-center items-center text-white shadow-[0_4px_10px_rgba(16,185,129,0.3)] transition-transform duration-300 hover:scale-110 active:scale-95
+                       md:static md:translate-x-0">
+                <i class="fas fa-plus text-[24px]"></i>
+            </router-link>
+
             <router-link :to="{ name: 'home' }"
                 class="group flex flex-col items-center text-slate-400 text-xs transition-all duration-300 [&.active]:text-emerald-500 [&.active]:font-bold"
                 exact-active-class="active">
                 <i
-                    class="fas fa-home text-[20px] mb-1 transition-transform duration-300 group-[.active]:-translate-y-[3px] group-[.active]:scale-[1.15]"></i>
+                    class="fas fa-home text-[20px] mb-1 transition-transform duration-300 group-[.active]:-translate-y-[3px] group-[.active]:scale-[1.15] md:text-[24px] md:mb-2"></i>
                 <span>홈</span>
             </router-link>
 
@@ -18,7 +21,7 @@
                 class="group flex flex-col items-center text-slate-400 text-xs transition-all duration-300 [&.active]:text-emerald-500 [&.active]:font-bold"
                 active-class="active">
                 <i
-                    class="fas fa-calendar-alt text-[20px] mb-1 transition-transform duration-300 group-[.active]:-translate-y-[3px] group-[.active]:scale-[1.15]"></i>
+                    class="fas fa-calendar-alt text-[20px] mb-1 transition-transform duration-300 group-[.active]:-translate-y-[3px] group-[.active]:scale-[1.15] md:text-[24px] md:mb-2"></i>
                 <span>월간</span>
             </router-link>
 
@@ -26,7 +29,7 @@
                 class="group flex flex-col items-center text-slate-400 text-xs transition-all duration-300 [&.active]:text-emerald-500 [&.active]:font-bold"
                 active-class="active">
                 <i
-                    class="fas fa-chart-pie text-[20px] mb-1 transition-transform duration-300 group-[.active]:-translate-y-[3px] group-[.active]:scale-[1.15]"></i>
+                    class="fas fa-chart-pie text-[20px] mb-1 transition-transform duration-300 group-[.active]:-translate-y-[3px] group-[.active]:scale-[1.15] md:text-[24px] md:mb-2"></i>
                 <span>통계</span>
             </router-link>
 
@@ -34,7 +37,7 @@
                 class="group flex flex-col items-center text-slate-400 text-xs transition-all duration-300 [&.active]:text-emerald-500 [&.active]:font-bold"
                 active-class="active">
                 <i
-                    class="fas fa-list text-[20px] mb-1 transition-transform duration-300 group-[.active]:-translate-y-[3px] group-[.active]:scale-[1.15]"></i>
+                    class="fas fa-list text-[20px] mb-1 transition-transform duration-300 group-[.active]:-translate-y-[3px] group-[.active]:scale-[1.15] md:text-[24px] md:mb-2"></i>
                 <span>목록</span>
             </router-link>
         </nav>
@@ -47,10 +50,8 @@ import { useRoute } from 'vue-router';
 
 const route = useRoute();
 
-// 숨기고 싶은 라우트 이름들
 const hideNavBarRoutes = ['momo/edit', 'notfound'];
 
-// 현재 라우트가 숨김 목록에 없을 때만 true 반환
 const showNavBar = computed(() => {
     return !hideNavBarRoutes.includes(route.name);
 });


### PR DESCRIPTION
- [x] 데스크탑 뷰일 경우 navbar를 사이드바로 이동
- [x] 스크롤을 내려도 사이드바의 위치를 고정시킴

[스크롤 내리기 전 사이드바 위치]
<img width="914" height="808" alt="스크롤 내리기 전 사이드바 고정" src="https://github.com/user-attachments/assets/3bf9219c-aa54-403f-abfa-aebb28a81805" />

[스크롤 내린 후 사이드바 위치]
<img width="924" height="793" alt="스크롤 내린 후 사이드바 고정" src="https://github.com/user-attachments/assets/2d5ddd4b-4c86-45d7-8c7e-291ace9e5322" />
