### PR TITLE
[#124] 출석 경험치와 경험치 표시 방식 개선

### DIFF
--- a/front/src/components/Attendance.vue
+++ b/front/src/components/Attendance.vue
@@ -1,10 +1,16 @@
 <script setup>
+import { computed } from 'vue';
+
 const props = defineProps({
   checkedInToday: {
     type: Boolean,
     default: false,
   },
   attendance: {
+    type: Number,
+    default: 0,
+  },
+  rewardExp: {
     type: Number,
     default: 0,
   },
@@ -15,6 +21,14 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['attend']);
+
+const titleText = computed(() => {
+  if (props.checkedInToday) {
+    return `\uC5F0\uC18D ${props.attendance}\uC77C \uCD9C\uC11D`;
+  }
+
+  return '\uCD9C\uC11D\uD558\uAE30';
+});
 
 const handleClick = () => {
   if (props.checkedInToday || props.loading) {
@@ -36,8 +50,18 @@ const handleClick = () => {
     <p class="text-xs font-semibold tracking-[0.14em] text-emerald-600">
       ATTENDANCE
     </p>
-    <p class="mt-3 text-lg font-bold">
-      {{ checkedInToday ? `연속 ${attendance}일 출석` : '출석하기' }}
-    </p>
+
+    <div class="mt-3 flex flex-col items-start gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+      <p class="text-lg font-bold leading-snug">
+        {{ titleText }}
+      </p>
+
+      <span
+        v-if="rewardExp > 0"
+        class="shrink-0 rounded-full bg-emerald-50 px-3 py-1 text-[11px] font-bold text-emerald-600"
+      >
+        +{{ rewardExp.toLocaleString() }} EXP
+      </span>
+    </div>
   </button>
 </template>

--- a/front/src/components/Mission.vue
+++ b/front/src/components/Mission.vue
@@ -4,6 +4,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  rewardLabel: {
+    type: String,
+    default: '',
+  },
   disabled: {
     type: Boolean,
     default: false,
@@ -30,8 +34,18 @@ const handleClick = () => {
     @click="handleClick"
   >
     <p class="text-xs font-semibold tracking-[0.14em] text-emerald-600">MISSION</p>
-    <p class="mt-3 line-clamp-2 text-lg font-bold">
-      {{ missionText || '미션 받기' }}
-    </p>
+
+    <div class="mt-3 flex flex-col items-start gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+      <p class="line-clamp-2 text-lg font-bold leading-snug">
+        {{ missionText || '\uBBF8\uC158 \uBC1B\uAE30' }}
+      </p>
+
+      <span
+        v-if="rewardLabel"
+        class="shrink-0 rounded-full bg-emerald-50 px-3 py-1 text-[11px] font-bold text-emerald-600"
+      >
+        {{ rewardLabel }}
+      </span>
+    </div>
   </button>
 </template>

--- a/front/src/components/MissionDetail.vue
+++ b/front/src/components/MissionDetail.vue
@@ -26,7 +26,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['update:modelValue', 'close']);
+const emit = defineEmits(['update:modelValue', 'close', 'settled']);
 
 const momoStore = useMomoStore();
 
@@ -207,6 +207,7 @@ const completeSettlement = async () => {
 
     settlementResult.value = result.isSuccess ? 'success' : 'fail';
     settlementStep.value = 'result';
+    emit('settled', result);
   } catch (error) {
     console.error('completeSettlement error:', error);
     isSettling.value = false;

--- a/front/src/pages/HomePage.vue
+++ b/front/src/pages/HomePage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import Tank from '@/components/Tank.vue';
 import Momo from '@/components/Momo.vue';
@@ -18,6 +18,9 @@ const momoStore = useMomoStore();
 const isMissionModalOpen = ref(false);
 const isLogoutModalOpen = ref(false);
 const isMomoGuideModalOpen = ref(false);
+const toastMessage = ref('');
+const isToastVisible = ref(false);
+let toastTimerId = null;
 
 const ensureSession = () => {
   authStore.restoreSession();
@@ -75,6 +78,17 @@ const missionText = computed(() => {
 });
 const hasCheckedInToday = computed(() => {
   return momoStore.momoFinalAttendance === formatDate(new Date());
+});
+const missionRewardLabel = computed(() => {
+  if (!isLoggedIn.value) {
+    return '';
+  }
+
+  if (needsMissionSettlement.value) {
+    return '+300 EXP';
+  }
+
+  return '\uC131\uACF5 \uC2DC +300 EXP';
 });
 const currentMonthKey = computed(() => {
   const today = new Date();
@@ -177,6 +191,46 @@ const getAttendanceRewardExp = (attendance, isFirstAttendance = false) => {
   return 290;
 };
 
+const nextAttendanceRewardExp = computed(() => {
+  if (!isLoggedIn.value || hasCheckedInToday.value) {
+    return 0;
+  }
+
+  const today = new Date();
+  const lastAttendanceDate = toDateOnly(momoStore.momoFinalAttendance);
+  const isFirstAttendance = !momoStore.momoFinalAttendance;
+
+  let nextAttendance = 1;
+
+  if (lastAttendanceDate) {
+    const diffDays = getDiffDays(lastAttendanceDate, today);
+
+    if (diffDays === 1) {
+      nextAttendance = momoStore.momoAttendance + 1;
+    }
+  }
+
+  return getAttendanceRewardExp(nextAttendance, isFirstAttendance);
+});
+
+const showToast = (message) => {
+  if (!message) {
+    return;
+  }
+
+  toastMessage.value = message;
+  isToastVisible.value = true;
+
+  if (toastTimerId) {
+    window.clearTimeout(toastTimerId);
+  }
+
+  toastTimerId = window.setTimeout(() => {
+    isToastVisible.value = false;
+    toastTimerId = null;
+  }, 2200);
+};
+
 const fetchHomeData = async (userId) => {
   if (!userId) {
     return;
@@ -208,9 +262,8 @@ const handleAttendance = async () => {
     }
   }
 
-  const nextExp =
-    momoStore.momoExp +
-    getAttendanceRewardExp(nextAttendance, isFirstAttendance);
+  const rewardExp = getAttendanceRewardExp(nextAttendance, isFirstAttendance);
+  const nextExp = momoStore.momoExp + rewardExp;
 
   await momoStore.updateMomoAttendance(
     effectiveUserId.value,
@@ -218,6 +271,8 @@ const handleAttendance = async () => {
     todayString,
     nextExp,
   );
+
+  showToast(`\uCD9C\uC11D \uC644\uB8CC! +${rewardExp.toLocaleString()} EXP`);
 };
 
 const openMissionModal = () => {
@@ -240,6 +295,14 @@ const goToMyPage = () => {
   router.push({ name: 'momo/mypage' });
 };
 
+const handleMissionSettled = (result) => {
+  if (!result?.isSuccess || !result.rewardExp) {
+    return;
+  }
+
+  showToast(`\uBBF8\uC158 \uC131\uACF5! +${result.rewardExp.toLocaleString()} EXP`);
+};
+
 watch(
   effectiveUserId,
   async (userId) => {
@@ -255,6 +318,12 @@ watch(
 
 onMounted(() => {
   ensureSession();
+});
+
+onBeforeUnmount(() => {
+  if (toastTimerId) {
+    window.clearTimeout(toastTimerId);
+  }
 });
 </script>
 
@@ -311,12 +380,14 @@ onMounted(() => {
               <Attendance
                 :checkedInToday="hasCheckedInToday"
                 :attendance="momoStore.momoAttendance"
+                :rewardExp="nextAttendanceRewardExp"
                 :loading="momoStore.isFetching"
                 @attend="handleAttendance"
               />
 
               <Mission
                 :missionText="missionText"
+                :rewardLabel="missionRewardLabel"
                 :disabled="hasMissionForToday"
                 @open="openMissionModal"
               />
@@ -342,6 +413,7 @@ onMounted(() => {
       :needsSettlement="needsMissionSettlement"
       :userId="effectiveUserId"
       @close="isMissionModalOpen = false"
+      @settled="handleMissionSettled"
       @update:modelValue="isMissionModalOpen = $event"
     />
 
@@ -350,6 +422,24 @@ onMounted(() => {
       @close="isMomoGuideModalOpen = false"
       @update:modelValue="isMomoGuideModalOpen = $event"
     />
+
+    <teleport to="body">
+      <transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="translate-y-2 opacity-0"
+        enter-to-class="translate-y-0 opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="translate-y-0 opacity-100"
+        leave-to-class="translate-y-2 opacity-0"
+      >
+        <div
+          v-if="isToastVisible"
+          class="fixed left-1/2 top-6 z-[10000] -translate-x-1/2 rounded-full bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-[0_18px_40px_rgba(15,23,42,0.24)]"
+        >
+          {{ toastMessage }}
+        </div>
+      </transition>
+    </teleport>
 
     <teleport to="body">
       <div

--- a/front/src/stores/momo.js
+++ b/front/src/stores/momo.js
@@ -197,6 +197,7 @@ export const useMomoStore = defineStore('momo', () => {
     userId,
     { missionCategory, missionAssignedAt },
   ) => {
+    const successRewardExp = 300;
     const response = await axios.get(`${BASE_URL}/transactions`, {
       params: {
         userId,
@@ -215,13 +216,14 @@ export const useMomoStore = defineStore('momo', () => {
     };
 
     if (isSuccess) {
-      payload.momoExp = momoExp.value + 300;
+      payload.momoExp = momoExp.value + successRewardExp;
     }
 
     await editMomoData(userId, payload);
 
     return {
       isSuccess,
+      rewardExp: isSuccess ? successRewardExp : 0,
       matchedTransactions: response.data,
     };
   };


### PR DESCRIPTION
## 경험치 변경 사항

### 출석 경험치 조정
- 최초 출석 보상: `990 EXP`
- 일반 출석 보상 시작값: `200 EXP`
- 연속 출석 시 보상 증가폭 유지
  - 2일차: `220 EXP`
  - 3일차: `240 EXP`
  - 4일차: `260 EXP`
  - 5일차: `270 EXP`
  - 6일차: `280 EXP`
  - 7일차 이상: `290 EXP`

### 경험치 표시 방식 개선
- 출석 카드에 오늘 획득 예정 경험치를 `+EXP` 배지로 표시
- 미션 카드에도 같은 형식의 `+EXP` 배지 표시
- 연속 출석 여부에 따라 출석 보상이 동적으로 변경되어 표시됨
  - 예: `+200 EXP`, `+220 EXP`
- 출석 완료 시 토스트 메시지로 실제 획득 경험치 표시
  - 예: `출석 완료! +200 EXP`
- 미션 성공 시 토스트 메시지로 실제 획득 경험치 표시
  - 예: `미션 성공! +300 EXP`
