### PR TITLE
[#128] 미션 정산 방식 설명 모달 추가

### DIFF
--- a/front/src/components/Mission.vue
+++ b/front/src/components/Mission.vue
@@ -4,6 +4,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  showGuideButton: {
+    type: Boolean,
+    default: false,
+  },
   rewardLabel: {
     type: String,
     default: '',
@@ -14,7 +18,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['open']);
+const emit = defineEmits(['open', 'open-guide']);
 
 const handleClick = () => {
   if (props.disabled) {
@@ -22,6 +26,11 @@ const handleClick = () => {
   }
 
   emit('open');
+};
+
+const handleGuideClick = (event) => {
+  event.stopPropagation();
+  emit('open-guide');
 };
 </script>
 
@@ -33,9 +42,22 @@ const handleClick = () => {
     :aria-disabled="disabled"
     @click="handleClick"
   >
-    <p class="text-xs font-semibold tracking-[0.14em] text-emerald-600">MISSION</p>
+    <div class="flex items-center justify-between gap-3">
+      <p class="text-xs font-semibold tracking-[0.14em] text-emerald-600">MISSION</p>
 
-    <div class="mt-3 flex flex-col items-start gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+      <button
+        v-if="showGuideButton"
+        type="button"
+        class="-mt-2 flex h-8 shrink-0 items-center justify-center gap-1 rounded-full bg-emerald-50 px-2 text-emerald-600 transition active:scale-95"
+        aria-label="미션 도움말 보기"
+        @click="handleGuideClick"
+      >
+        <i class="fa-solid fa-book-open text-[15px]"></i>
+        <i class="fa-solid fa-circle-question text-[14px]"></i>
+      </button>
+    </div>
+
+    <div class="mt-2 flex flex-col items-start gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
       <p class="line-clamp-2 text-lg font-bold leading-snug">
         {{ missionText || '\uBBF8\uC158 \uBC1B\uAE30' }}
       </p>

--- a/front/src/components/MissionGuideModal.vue
+++ b/front/src/components/MissionGuideModal.vue
@@ -1,0 +1,72 @@
+<script setup>
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  missionCategory: {
+    type: String,
+    default: '',
+  },
+});
+
+const emit = defineEmits(['update:modelValue', 'close']);
+
+const closeModal = () => {
+  emit('update:modelValue', false);
+  emit('close');
+};
+</script>
+
+<template>
+  <teleport to="body">
+    <div
+      v-if="props.modelValue"
+      class="fixed inset-0 z-[9999] flex items-center justify-center bg-slate-900/35 px-4 py-8"
+      @click.self="closeModal"
+    >
+      <section
+        class="w-full max-w-[360px] overflow-hidden rounded-[28px] bg-white shadow-[0_24px_80px_rgba(15,23,42,0.24)]"
+      >
+        <div class="bg-[linear-gradient(135deg,#34d399_0%,#14b8a6_100%)] px-5 py-5 text-white">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <p class="text-xs font-semibold tracking-[0.18em] text-white/70">MISSION GUIDE</p>
+              <h2 class="mt-1 text-xl font-bold">미션 정산 안내</h2>
+            </div>
+            <button
+              type="button"
+              class="flex h-11 w-11 items-center justify-center rounded-full bg-white/15 text-xl font-semibold text-white"
+              @click="closeModal"
+            >
+              X
+            </button>
+          </div>
+        </div>
+
+        <div class="px-5 py-5">
+          <div class="rounded-[24px] bg-emerald-50 px-4 py-4">
+            <p class="text-sm font-semibold text-emerald-700">현재 미션</p>
+            <p class="mt-2 text-xl font-bold text-slate-900">
+              {{ missionCategory ? `${missionCategory} 절약하기` : '오늘의 미션 진행 중' }}
+            </p>
+          </div>
+
+          <div class="mt-4 space-y-3 rounded-[24px] border border-slate-100 bg-slate-50 px-4 py-5 text-sm leading-6 text-slate-600">
+            <p>1. 오늘 받은 미션 카테고리의 지출을 기록하지 않으면 성공이야.</p>
+            <p>2. 해당 카테고리 지출이 있으면 미션은 실패로 정산돼!</p>
+            <p>3. 다음날 미션 카드가 `미션 정산하기`로 바뀌면 눌러서 결과를 확인하면 돼.</p>
+          </div>
+
+          <button
+            type="button"
+            class="mt-5 w-full rounded-[18px] bg-[linear-gradient(135deg,#34d399_0%,#14b8a6_100%)] px-4 py-3 text-sm font-bold text-white"
+            @click="closeModal"
+          >
+            확인했어요
+          </button>
+        </div>
+      </section>
+    </div>
+  </teleport>
+</template>

--- a/front/src/pages/HomePage.vue
+++ b/front/src/pages/HomePage.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router';
 import Tank from '@/components/Tank.vue';
 import Momo from '@/components/Momo.vue';
 import MomoGuideModal from '@/components/MomoGuideModal.vue';
+import MissionGuideModal from '@/components/MissionGuideModal.vue';
 import ExpBar from '@/components/ExpBar.vue';
 import Attendance from '@/components/Attendance.vue';
 import Mission from '@/components/Mission.vue';
@@ -16,6 +17,7 @@ const authStore = useAuthStore();
 const momoStore = useMomoStore();
 
 const isMissionModalOpen = ref(false);
+const isMissionGuideModalOpen = ref(false);
 const isLogoutModalOpen = ref(false);
 const isMomoGuideModalOpen = ref(false);
 const toastMessage = ref('');
@@ -387,9 +389,11 @@ onBeforeUnmount(() => {
 
               <Mission
                 :missionText="missionText"
+                :showGuideButton="hasMissionForToday"
                 :rewardLabel="missionRewardLabel"
                 :disabled="hasMissionForToday"
                 @open="openMissionModal"
+                @open-guide="isMissionGuideModalOpen = true"
               />
             </div>
           </template>
@@ -415,6 +419,13 @@ onBeforeUnmount(() => {
       @close="isMissionModalOpen = false"
       @settled="handleMissionSettled"
       @update:modelValue="isMissionModalOpen = $event"
+    />
+
+    <MissionGuideModal
+      :modelValue="isMissionGuideModalOpen"
+      :missionCategory="momoStore.momoMission"
+      @close="isMissionGuideModalOpen = false"
+      @update:modelValue="isMissionGuideModalOpen = $event"
     />
 
     <MomoGuideModal


### PR DESCRIPTION
## 미션 정산 안내 모달 추가

### 기능 추가
- 미션 진행 중일 때 정산 방식을 설명하는 안내 모달 컴포넌트 추가
- 사용자가 `교통 절약하기` 같은 미션 상태에서 언제 정산할 수 있는지 바로 확인 가능하도록 개선

### UI 변경
- 미션 카드 상단에 도움말 아이콘 버튼 추가
- 책 아이콘과 물음표를 조합해 `도움말` 의미가 직관적으로 보이도록 구성
- 모바일 화면에서도 레이아웃이 어색하지 않도록 버튼 위치 조정

### 모달 내용
- 현재 진행 중인 미션 표시
- 미션 성공 조건 안내
- 미션 실패 조건 안내
- 다음날 `미션 정산하기` 상태로 바뀌면 결과를 확인할 수 있다는 점 간단히 설명
