### PR TITLE
[#129] EditPage 카테고리 미선택 인라인 에러 메시지 위치 개선

### DIFF
--- a/front/src/pages/MomoEditPage.vue
+++ b/front/src/pages/MomoEditPage.vue
@@ -540,13 +540,20 @@ watch(
           </section>
         </div>
 
-        <section class="w-full rounded-[24px] bg-white p-4 shadow-sm lg:col-start-2 lg:row-span-4 lg:row-start-1 lg:p-5">
-          <h2 class="text-[28px] font-extrabold text-slate-900">카테고리</h2>
+          <section class="w-full rounded-[24px] bg-white p-4 shadow-sm lg:col-start-2 lg:row-span-4 lg:row-start-1 lg:p-5">
+            <h2 class="text-[28px] font-extrabold text-slate-900">카테고리</h2>
 
-          <div class="mt-6 grid grid-cols-4 gap-x-2 gap-y-5 sm:gap-x-3">
-            <button
-              v-for="category in currentCategories"
-              :key="category.key"
+            <p
+              v-if="formError.category"
+              class="mt-4 rounded-2xl bg-rose-50 px-4 py-3 text-sm font-medium text-rose-500"
+            >
+              {{ formError.category }}
+            </p>
+
+            <div class="mt-6 grid grid-cols-4 gap-x-2 gap-y-5 sm:gap-x-3">
+              <button
+                v-for="category in currentCategories"
+                :key="category.key"
               type="button"
               class="flex flex-col items-center gap-2 text-center"
               @click="selectCategory(category)"
@@ -571,13 +578,7 @@ watch(
             </button>
           </div>
 
-          <p
-            v-if="formError.category"
-            class="mt-4 rounded-2xl bg-rose-50 px-4 py-3 text-sm font-medium text-rose-500"
-          >
-            {{ formError.category }}
-          </p>
-        </section>
+          </section>
 
         <section class="w-full rounded-[24px] bg-white p-5 shadow-sm lg:col-start-1 lg:row-start-2">
           <h2 class="text-[28px] font-extrabold text-slate-900">메모</h2>


### PR DESCRIPTION
## 카테고리 미선택 인라인 에러 메시지 위치 개선

### 문제
- 카테고리를 선택하지 않았을 때 에러 메시지가 카테고리 카드 하단에 표시되어
  사용자가 바로 인지하기 어려운 문제가 있었음

### 개선 내용
- 카테고리 인라인 에러 메시지를 카드 하단에서 카드 상단으로 이동
- `카테고리` 제목 바로 아래에 에러 메시지가 보이도록 수정

### 기대 효과
- 사용자가 카테고리 선택 누락을 더 빠르게 인지 가능
- 입력 오류 위치와 안내 메시지의 연결성이 더 자연스러워짐
