### PR TITLE
[#136] 카테고리별 거래 내역 확인

### DIFF
--- a/front/src/constants/momoCategories.js
+++ b/front/src/constants/momoCategories.js
@@ -1,4 +1,4 @@
-export const categoryMap = {
+﻿export const categoryMap = {
   expense: [
     {
       key: 'food',
@@ -30,7 +30,7 @@ export const categoryMap = {
     },
     {
       key: 'hobby',
-      label: '취미활동',
+      label: '취미/여가',
       icon: 'fa-solid fa-gamepad',
       iconClass: 'text-fuchsia-500',
       activeClass: 'bg-fuchsia-50 text-fuchsia-600 ring-fuchsia-200',

--- a/front/src/pages/MomoFullListPage.vue
+++ b/front/src/pages/MomoFullListPage.vue
@@ -73,7 +73,7 @@ const formatRangeLabelDate = (date) => {
   return `${normalized.getFullYear()}.${String(normalized.getMonth() + 1).padStart(2, '0')}.${String(normalized.getDate()).padStart(2, '0')}`;
 };
 
-const selectedRange = ref(getMonthRange());
+const selectedRange = ref(null);
 
 const normalizedRange = computed(() => {
   if (!selectedRange.value?.start && !selectedRange.value?.end) {
@@ -372,7 +372,7 @@ watch(
     selectedCategories.value = [];
     isFilterOpen.value = false;
     showCalendar.value = false;
-    selectedRange.value = getMonthRange();
+    selectedRange.value = null;
 
     await loadInitialTransactions(newUserId);
     await scrollToHashTarget();
@@ -441,7 +441,7 @@ watch(
             >
               <span class="flex min-w-0 items-center gap-2">
                 <i class="fa-solid fa-calendar-days shrink-0 text-emerald-500"></i>
-                <span class="truncate">기간</span>
+                <span class="truncate">{{ rangeLabel }}</span>
               </span>
               <i
                 class="fa-solid fa-chevron-down shrink-0 text-[11px] text-slate-400 transition-transform"

--- a/front/src/pages/MomoFullListPage.vue
+++ b/front/src/pages/MomoFullListPage.vue
@@ -1,13 +1,24 @@
 <script setup>
-import { computed, onMounted, watch, nextTick } from 'vue';
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
 import AppHeader from '@/components/AppHeader.vue';
 import TransactionCard from '@/components/TransactionCard.vue';
+import { categoryMap } from '@/constants/momoCategories';
 import { useMomoStore } from '@/stores/momo';
 
 const momoStore = useMomoStore();
 const route = useRoute();
+
+const selectedCategory = ref('');
+const isFilterOpen = ref(false);
+const availableCategories = ref([]);
+
+const categoryMetaMap = Object.values(categoryMap).flat().reduce((acc, item) => {
+  acc[item.key] = item;
+  acc[item.label] = item;
+  return acc;
+}, {});
 
 const sortedTransactions = computed(() => {
   return [...momoStore.transactionList].sort(
@@ -16,51 +27,147 @@ const sortedTransactions = computed(() => {
 });
 
 const groupedTransactions = computed(() => {
-  const map = {};
+  const groupedMap = {};
 
   sortedTransactions.value.forEach((item) => {
-    if (!map[item.date]) {
-      map[item.date] = [];
+    if (!groupedMap[item.date]) {
+      groupedMap[item.date] = [];
     }
-    map[item.date].push(item);
+
+    groupedMap[item.date].push(item);
   });
 
-  return Object.entries(map).map(([date, items]) => ({
+  return Object.entries(groupedMap).map(([date, items]) => ({
     date,
     items,
   }));
 });
 
+const filterOptions = computed(() => {
+  return availableCategories.value.map((category) => {
+    const meta = categoryMetaMap[category];
+
+    return {
+      value: category,
+      label: meta?.label ?? category,
+      icon: meta?.icon ?? 'fa-solid fa-tag',
+      iconClass: meta?.iconClass ?? 'text-slate-400',
+    };
+  });
+});
+
+const selectedCategoryLabel = computed(() => {
+  if (!selectedCategory.value) {
+    return '전체';
+  }
+
+  return categoryMetaMap[selectedCategory.value]?.label || selectedCategory.value;
+});
+
+const headerSubtitle = computed(() => {
+  return selectedCategory.value
+    ? '카테고리 내역을 날짜별로 확인할 수 있어요'
+    : '전체 거래 내역을 날짜별로 확인할 수 있어요';
+});
+
+const emptyMessage = computed(() => {
+  return selectedCategory.value
+    ? '선택한 카테고리 내역이 아직 없어요.'
+    : '거래 내역이 아직 없어요.';
+});
+
 const formatDateLabel = (dateString) => {
-  const d = new Date(dateString);
-  return `${d.getMonth() + 1}월 ${d.getDate()}일`;
+  const date = new Date(dateString);
+  return `${date.getMonth() + 1}월 ${date.getDate()}일`;
 };
 
 const makeDateAnchorId = (dateString) => {
   return `date-${dateString}`;
 };
 
+const syncAvailableCategories = (transactions) => {
+  availableCategories.value = [...new Set(
+    transactions
+      .map((item) => item.category)
+      .filter(Boolean),
+  )].sort((a, b) => a.localeCompare(b, 'ko-KR'));
+};
+
+const loadTransactions = async (userId, category = '') => {
+  const transactions = await momoStore.fetchTransactionList(
+    userId,
+    category ? { category } : {},
+  );
+
+  return transactions ?? [];
+};
+
+const loadInitialTransactions = async (userId) => {
+  const transactions = await loadTransactions(userId);
+  syncAvailableCategories(transactions);
+
+  if (
+    selectedCategory.value &&
+    !availableCategories.value.includes(selectedCategory.value)
+  ) {
+    selectedCategory.value = '';
+    await loadTransactions(userId);
+  }
+};
+
+const applyCategoryFilter = async (category) => {
+  if (!momoStore.currentMomoUserId) {
+    return;
+  }
+
+  selectedCategory.value = category;
+  isFilterOpen.value = false;
+
+  await loadTransactions(momoStore.currentMomoUserId, category);
+  await scrollToHashTarget();
+};
+
+const clearCategoryFilter = async () => {
+  if (!momoStore.currentMomoUserId) {
+    return;
+  }
+
+  selectedCategory.value = '';
+  isFilterOpen.value = false;
+
+  await loadTransactions(momoStore.currentMomoUserId);
+  await scrollToHashTarget();
+};
+
+const toggleFilter = () => {
+  isFilterOpen.value = !isFilterOpen.value;
+};
+
 const scrollToHashTarget = async () => {
   await nextTick();
 
-  if (route.hash) {
-    const id = route.hash.replace('#', '');
-    const el = document.getElementById(id);
-
-    if (el) {
-      const y = el.getBoundingClientRect().top + window.scrollY - 110;
-
-      window.scrollTo({
-        top: y,
-        behavior: 'smooth',
-      });
-    }
+  if (!route.hash) {
+    return;
   }
+
+  const id = route.hash.replace('#', '');
+  const el = document.getElementById(id);
+
+  if (!el) {
+    return;
+  }
+
+  const y = el.getBoundingClientRect().top + window.scrollY - 110;
+
+  window.scrollTo({
+    top: y,
+    behavior: 'smooth',
+  });
 };
 
 onMounted(async () => {
   if (momoStore.currentMomoUserId) {
-    await momoStore.fetchTransactionList(momoStore.currentMomoUserId);
+    await loadInitialTransactions(momoStore.currentMomoUserId);
   }
 
   await scrollToHashTarget();
@@ -69,9 +176,14 @@ onMounted(async () => {
 watch(
   () => momoStore.currentMomoUserId,
   async (newUserId, oldUserId) => {
-    if (!newUserId || newUserId === oldUserId) return;
+    if (!newUserId || newUserId === oldUserId) {
+      return;
+    }
 
-    await momoStore.fetchTransactionList(newUserId);
+    selectedCategory.value = '';
+    isFilterOpen.value = false;
+
+    await loadInitialTransactions(newUserId);
     await scrollToHashTarget();
   },
 );
@@ -86,9 +198,93 @@ watch(
     >
       <AppHeader
         title="목록"
-        subtitle="전체 거래 내역을 날짜별로 확인할 수 있어요"
+        :subtitle="headerSubtitle"
         iconClass="fa-solid fa-list"
       />
+
+      <section class="relative mb-6 flex justify-end">
+        <button
+          type="button"
+          class="inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-emerald-200 hover:bg-emerald-50"
+          @click="toggleFilter"
+        >
+          <i class="fa-solid fa-filter text-emerald-500"></i>
+          <span>{{ selectedCategoryLabel }}</span>
+          <i
+            class="fa-solid fa-chevron-down text-[11px] text-slate-400 transition-transform"
+            :class="{ 'rotate-180': isFilterOpen }"
+          ></i>
+        </button>
+
+        <div
+          v-if="isFilterOpen"
+          class="absolute top-full right-0 z-20 mt-3 w-[280px] rounded-[24px] border border-slate-200 bg-white p-3 shadow-[0_20px_50px_rgba(15,23,42,0.12)]"
+        >
+          <div class="mb-3 flex items-center justify-between px-2">
+            <strong class="text-sm font-bold text-slate-900">
+              카테고리 선택
+            </strong>
+            <button
+              type="button"
+              class="text-xs font-medium text-slate-400 transition hover:text-slate-600"
+              @click="isFilterOpen = false"
+            >
+              닫기
+            </button>
+          </div>
+
+          <div class="max-h-[320px] space-y-2 overflow-y-auto pr-1">
+            <button
+              type="button"
+              class="flex w-full items-center justify-between rounded-[18px] px-4 py-3 text-left text-sm font-semibold transition"
+              :class="
+                !selectedCategory
+                  ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                  : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
+              "
+              @click="clearCategoryFilter"
+            >
+              <span class="flex items-center gap-3">
+                <i class="fa-solid fa-layer-group text-emerald-500"></i>
+                전체 보기
+              </span>
+              <i
+                v-if="!selectedCategory"
+                class="fa-solid fa-check text-xs text-emerald-500"
+              ></i>
+            </button>
+
+            <button
+              v-for="option in filterOptions"
+              :key="option.value"
+              type="button"
+              class="flex w-full items-center justify-between rounded-[18px] px-4 py-3 text-left text-sm font-semibold transition"
+              :class="
+                selectedCategory === option.value
+                  ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                  : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
+              "
+              @click="applyCategoryFilter(option.value)"
+            >
+              <span class="flex items-center gap-3">
+                <i :class="[option.icon, option.iconClass]"></i>
+                {{ option.label }}
+              </span>
+              <i
+                v-if="selectedCategory === option.value"
+                class="fa-solid fa-check text-xs text-emerald-500"
+              ></i>
+            </button>
+
+            <p
+              v-if="filterOptions.length === 0"
+              class="rounded-[18px] bg-slate-50 px-4 py-5 text-center text-sm text-slate-400"
+            >
+              아직 선택할 수 있는 카테고리가 없어요.
+            </p>
+          </div>
+        </div>
+      </section>
 
       <div class="grid gap-6 lg:grid-cols-2 lg:items-start">
         <template v-if="groupedTransactions.length > 0">
@@ -122,7 +318,7 @@ watch(
           v-else
           class="py-10 text-center text-sm font-medium text-slate-400 lg:col-span-2"
         >
-          거래 내역이 없습니다.
+          {{ emptyMessage }}
         </p>
       </div>
     </div>

--- a/front/src/pages/MomoFullListPage.vue
+++ b/front/src/pages/MomoFullListPage.vue
@@ -1,5 +1,5 @@
-<script setup>
-import { computed, nextTick, onMounted, ref, watch } from 'vue';
+﻿<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 
 import AppHeader from '@/components/AppHeader.vue';
@@ -10,9 +10,117 @@ import { useMomoStore } from '@/stores/momo';
 const momoStore = useMomoStore();
 const route = useRoute();
 
-const selectedCategory = ref('');
+const allTransactions = ref([]);
+const selectedCategories = ref([]);
 const isFilterOpen = ref(false);
-const availableCategories = ref([]);
+const showCalendar = ref(false);
+const calendarContainerRef = ref(null);
+const filterContainerRef = ref(null);
+
+const getTodayDate = () => {
+  const today = new Date();
+  return new Date(today.getFullYear(), today.getMonth(), today.getDate());
+};
+
+const getMonthRange = (date = getTodayDate()) => ({
+  start: new Date(date.getFullYear(), date.getMonth(), 1),
+  end: new Date(date.getFullYear(), date.getMonth() + 1, 0),
+});
+
+const calendarMasks = {
+  title: 'YYYY년 M월',
+};
+
+const parseDateString = (dateString) => {
+  if (typeof dateString !== 'string') {
+    return null;
+  }
+
+  const [year, month, day] = dateString.split('-').map(Number);
+
+  if (!year || !month || !day) {
+    return null;
+  }
+
+  return new Date(year, month - 1, day);
+};
+
+const normalizeDate = (date) => {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+};
+
+const formatDateKey = (date) => {
+  const normalized = normalizeDate(date);
+
+  if (!normalized) {
+    return '';
+  }
+
+  return `${normalized.getFullYear()}-${String(normalized.getMonth() + 1).padStart(2, '0')}-${String(normalized.getDate()).padStart(2, '0')}`;
+};
+
+const formatRangeLabelDate = (date) => {
+  const normalized = normalizeDate(date);
+
+  if (!normalized) {
+    return '';
+  }
+
+  return `${normalized.getFullYear()}.${String(normalized.getMonth() + 1).padStart(2, '0')}.${String(normalized.getDate()).padStart(2, '0')}`;
+};
+
+const selectedRange = ref(getMonthRange());
+
+const normalizedRange = computed(() => {
+  if (!selectedRange.value?.start && !selectedRange.value?.end) {
+    return null;
+  }
+
+  const start = normalizeDate(selectedRange.value?.start);
+  const end = normalizeDate(selectedRange.value?.end ?? selectedRange.value?.start);
+
+  if (!start && !end) {
+    return null;
+  }
+
+  if (!start) {
+    return {
+      start: end,
+      end,
+    };
+  }
+
+  if (!end) {
+    return {
+      start,
+      end: start,
+    };
+  }
+
+  return start <= end
+    ? { start, end }
+    : { start: end, end: start };
+});
+
+const rangeLabel = computed(() => {
+  if (!normalizedRange.value) {
+    return '전체 기간';
+  }
+
+  const { start, end } = normalizedRange.value;
+  const startLabel = formatRangeLabelDate(start);
+  const endLabel = formatRangeLabelDate(end);
+
+  if (startLabel === endLabel) {
+    return startLabel;
+  }
+
+  return `${startLabel} - ${endLabel}`;
+});
 
 const categoryMetaMap = Object.values(categoryMap).flat().reduce((acc, item) => {
   acc[item.key] = item;
@@ -20,9 +128,74 @@ const categoryMetaMap = Object.values(categoryMap).flat().reduce((acc, item) => 
   return acc;
 }, {});
 
+const rangeFilteredTransactions = computed(() => {
+  if (!normalizedRange.value) {
+    return allTransactions.value;
+  }
+
+  return allTransactions.value.filter((item) => {
+    const targetDate = parseDateString(item.date);
+
+    if (!targetDate) {
+      return false;
+    }
+
+    const { start, end } = normalizedRange.value;
+    return targetDate >= start && targetDate <= end;
+  });
+});
+
+const availableCategories = computed(() => {
+  return [...new Set(
+    rangeFilteredTransactions.value
+      .map((item) => item.category)
+      .filter(Boolean),
+  )].sort((a, b) => a.localeCompare(b, 'ko-KR'));
+});
+
+const filterOptions = computed(() => {
+  return availableCategories.value.map((category) => {
+    const meta = categoryMetaMap[category];
+
+    return {
+      value: category,
+      label: meta?.label ?? category,
+      icon: meta?.icon ?? 'fa-solid fa-tag',
+      iconClass: meta?.iconClass ?? 'text-slate-400',
+    };
+  });
+});
+
+const hasActiveRange = computed(() => Boolean(normalizedRange.value));
+
+const hasActiveCategory = computed(() => selectedCategories.value.length > 0);
+
+const selectedCategoryChips = computed(() => {
+  return selectedCategories.value.map((category) => {
+    const meta = categoryMetaMap[category];
+
+    return {
+      value: category,
+      label: meta?.label ?? category,
+      icon: meta?.icon ?? 'fa-solid fa-tag',
+      iconClass: meta?.iconClass ?? 'text-slate-400',
+    };
+  });
+});
+
+const filteredTransactions = computed(() => {
+  if (!selectedCategories.value.length) {
+    return rangeFilteredTransactions.value;
+  }
+
+  return rangeFilteredTransactions.value.filter(
+    (item) => selectedCategories.value.includes(item.category),
+  );
+});
+
 const sortedTransactions = computed(() => {
-  return [...momoStore.transactionList].sort(
-    (a, b) => new Date(b.date) - new Date(a.date),
+  return [...filteredTransactions.value].sort(
+    (a, b) => parseDateString(b.date) - parseDateString(a.date),
   );
 });
 
@@ -43,41 +216,25 @@ const groupedTransactions = computed(() => {
   }));
 });
 
-const filterOptions = computed(() => {
-  return availableCategories.value.map((category) => {
-    const meta = categoryMetaMap[category];
-
-    return {
-      value: category,
-      label: meta?.label ?? category,
-      icon: meta?.icon ?? 'fa-solid fa-tag',
-      iconClass: meta?.iconClass ?? 'text-slate-400',
-    };
-  });
-});
-
-const selectedCategoryLabel = computed(() => {
-  if (!selectedCategory.value) {
-    return '전체';
-  }
-
-  return categoryMetaMap[selectedCategory.value]?.label || selectedCategory.value;
-});
-
 const headerSubtitle = computed(() => {
-  return selectedCategory.value
-    ? '카테고리 내역을 날짜별로 확인할 수 있어요'
-    : '전체 거래 내역을 날짜별로 확인할 수 있어요';
+  return selectedCategories.value.length
+    ? '선택한 기간 안에서 카테고리 내역을 날짜별로 볼 수 있어요.'
+    : '선택한 기간의 전체 거래 내역을 날짜별로 볼 수 있어요.';
 });
 
 const emptyMessage = computed(() => {
-  return selectedCategory.value
-    ? '선택한 카테고리 내역이 아직 없어요.'
-    : '거래 내역이 아직 없어요.';
+  return selectedCategories.value.length
+    ? '선택한 기간에 해당 카테고리 거래가 없어요.'
+    : '선택한 기간에 거래 내역이 없어요.';
 });
 
 const formatDateLabel = (dateString) => {
-  const date = new Date(dateString);
+  const date = parseDateString(dateString);
+
+  if (!date) {
+    return dateString;
+  }
+
   return `${date.getMonth() + 1}월 ${date.getDate()}일`;
 };
 
@@ -85,62 +242,88 @@ const makeDateAnchorId = (dateString) => {
   return `date-${dateString}`;
 };
 
-const syncAvailableCategories = (transactions) => {
-  availableCategories.value = [...new Set(
-    transactions
-      .map((item) => item.category)
-      .filter(Boolean),
-  )].sort((a, b) => a.localeCompare(b, 'ko-KR'));
+const toggleCalendar = () => {
+  if (!showCalendar.value) {
+    isFilterOpen.value = false;
+  }
+
+  showCalendar.value = !showCalendar.value;
 };
 
-const loadTransactions = async (userId, category = '') => {
-  const transactions = await momoStore.fetchTransactionList(
-    userId,
-    category ? { category } : {},
-  );
+const closeCalendar = () => {
+  showCalendar.value = false;
+};
 
-  return transactions ?? [];
+const clearDateRange = () => {
+  selectedRange.value = null;
+  showCalendar.value = false;
+};
+
+const resetToCurrentMonth = () => {
+  selectedRange.value = getMonthRange();
+};
+
+const loadTransactions = async (userId) => {
+  const transactions = await momoStore.fetchTransactionList(userId);
+  allTransactions.value = transactions ?? [];
+  return allTransactions.value;
 };
 
 const loadInitialTransactions = async (userId) => {
-  const transactions = await loadTransactions(userId);
-  syncAvailableCategories(transactions);
-
-  if (
-    selectedCategory.value &&
-    !availableCategories.value.includes(selectedCategory.value)
-  ) {
-    selectedCategory.value = '';
-    await loadTransactions(userId);
-  }
+  await loadTransactions(userId);
 };
 
-const applyCategoryFilter = async (category) => {
-  if (!momoStore.currentMomoUserId) {
-    return;
+const toggleCategoryFilter = async (category) => {
+  if (selectedCategories.value.includes(category)) {
+    selectedCategories.value = selectedCategories.value.filter(
+      (item) => item !== category,
+    );
+  } else {
+    selectedCategories.value = [...selectedCategories.value, category];
   }
 
-  selectedCategory.value = category;
-  isFilterOpen.value = false;
-
-  await loadTransactions(momoStore.currentMomoUserId, category);
   await scrollToHashTarget();
 };
 
 const clearCategoryFilter = async () => {
-  if (!momoStore.currentMomoUserId) {
-    return;
-  }
-
-  selectedCategory.value = '';
+  selectedCategories.value = [];
   isFilterOpen.value = false;
+  await scrollToHashTarget();
+};
 
-  await loadTransactions(momoStore.currentMomoUserId);
+const removeCategoryFilter = async (category) => {
+  selectedCategories.value = selectedCategories.value.filter(
+    (item) => item !== category,
+  );
   await scrollToHashTarget();
 };
 
 const toggleFilter = () => {
+  if (!isFilterOpen.value) {
+    showCalendar.value = false;
+  }
+
   isFilterOpen.value = !isFilterOpen.value;
+};
+
+const handleClickOutside = (event) => {
+  const target = event.target;
+
+  if (
+    showCalendar.value &&
+    calendarContainerRef.value &&
+    !calendarContainerRef.value.contains(target)
+  ) {
+    closeCalendar();
+  }
+
+  if (
+    isFilterOpen.value &&
+    filterContainerRef.value &&
+    !filterContainerRef.value.contains(target)
+  ) {
+    isFilterOpen.value = false;
+  }
 };
 
 const scrollToHashTarget = async () => {
@@ -166,11 +349,17 @@ const scrollToHashTarget = async () => {
 };
 
 onMounted(async () => {
+  document.addEventListener('pointerdown', handleClickOutside);
+
   if (momoStore.currentMomoUserId) {
     await loadInitialTransactions(momoStore.currentMomoUserId);
   }
 
   await scrollToHashTarget();
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', handleClickOutside);
 });
 
 watch(
@@ -180,12 +369,49 @@ watch(
       return;
     }
 
-    selectedCategory.value = '';
+    selectedCategories.value = [];
     isFilterOpen.value = false;
+    showCalendar.value = false;
+    selectedRange.value = getMonthRange();
 
     await loadInitialTransactions(newUserId);
     await scrollToHashTarget();
   },
+);
+
+watch(availableCategories, (categories) => {
+  if (!selectedCategories.value.length) {
+    return;
+  }
+
+  selectedCategories.value = selectedCategories.value.filter((category) =>
+    categories.includes(category),
+  );
+});
+
+watch(
+  normalizedRange,
+  async (range, previousRange) => {
+    if (!range && !previousRange) {
+      return;
+    }
+
+    if (
+      range &&
+      previousRange &&
+      formatDateKey(range.start) === formatDateKey(previousRange.start) &&
+      formatDateKey(range.end) === formatDateKey(previousRange.end)
+    ) {
+      return;
+    }
+
+    if (!range || (selectedRange.value?.start && selectedRange.value?.end)) {
+      showCalendar.value = false;
+    }
+
+    await scrollToHashTarget();
+  },
+  { deep: true },
 );
 </script>
 
@@ -202,87 +428,206 @@ watch(
         iconClass="fa-solid fa-list"
       />
 
-      <section class="relative mb-6 flex justify-end">
-        <button
-          type="button"
-          class="inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-emerald-200 hover:bg-emerald-50"
-          @click="toggleFilter"
-        >
-          <i class="fa-solid fa-filter text-emerald-500"></i>
-          <span>{{ selectedCategoryLabel }}</span>
-          <i
-            class="fa-solid fa-chevron-down text-[11px] text-slate-400 transition-transform"
-            :class="{ 'rotate-180': isFilterOpen }"
-          ></i>
-        </button>
+      <section class="relative mb-6 space-y-3">
+        <div class="flex items-center gap-3">
+          <div
+            ref="calendarContainerRef"
+            class="relative min-w-0 flex-1"
+          >
+            <button
+              type="button"
+              class="inline-flex w-full items-center justify-between gap-2 rounded-full border border-emerald-100 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-emerald-200 hover:bg-emerald-50"
+              @click="toggleCalendar"
+            >
+              <span class="flex min-w-0 items-center gap-2">
+                <i class="fa-solid fa-calendar-days shrink-0 text-emerald-500"></i>
+                <span class="truncate">기간</span>
+              </span>
+              <i
+                class="fa-solid fa-chevron-down shrink-0 text-[11px] text-slate-400 transition-transform"
+                :class="{ 'rotate-180': showCalendar }"
+              ></i>
+            </button>
+
+            <div
+              v-if="showCalendar"
+              class="absolute top-full left-0 z-20 mt-3 w-[320px] max-w-[calc(100vw-48px)] rounded-[24px] border border-slate-200 bg-white p-3 shadow-[0_20px_50px_rgba(15,23,42,0.12)]"
+            >
+              <section class="space-y-4 rounded-[20px]">
+                <div class="flex items-center justify-between gap-2 px-1">
+                  <div>
+                    <strong class="text-sm font-bold text-slate-900">
+                      기간 선택
+                    </strong>
+                    <p class="mt-1 text-xs text-slate-400">
+                      시작일과 종료일을 선택해 주세요.
+                    </p>
+                  </div>
+
+                  <button
+                    type="button"
+                    class="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-500 transition hover:bg-slate-200"
+                    @click="resetToCurrentMonth"
+                  >
+                    이번 달
+                  </button>
+                </div>
+
+                <VDatePicker
+                  v-model.range="selectedRange"
+                  :masks="calendarMasks"
+                  color="green"
+                  borderless
+                  transparent
+                  title-position="left"
+                  :max-date="getTodayDate()"
+                />
+
+                <div class="flex items-center justify-between gap-2 px-1">
+                  <span class="text-xs font-medium text-slate-500">
+                    {{ rangeLabel }}
+                  </span>
+
+                  <div class="flex items-center gap-2">
+                    <button
+                      type="button"
+                      class="rounded-full bg-slate-100 px-4 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-200"
+                      @click="clearDateRange"
+                    >
+                      전체 보기
+                    </button>
+
+                    <button
+                      type="button"
+                      class="rounded-full bg-emerald-500 px-4 py-2 text-xs font-semibold text-white transition hover:bg-emerald-600"
+                      @click="closeCalendar"
+                    >
+                      완료
+                    </button>
+                  </div>
+                </div>
+              </section>
+            </div>
+          </div>
+
+          <div
+            ref="filterContainerRef"
+            class="relative min-w-0 flex-1"
+          >
+            <button
+              type="button"
+              class="inline-flex w-full items-center justify-between gap-2 rounded-full border border-emerald-100 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-emerald-200 hover:bg-emerald-50"
+              @click="toggleFilter"
+            >
+              <span class="flex min-w-0 items-center gap-2">
+                <i class="fa-solid fa-filter shrink-0 text-emerald-500"></i>
+                <span class="truncate">필터</span>
+              </span>
+              <i
+                class="fa-solid fa-chevron-down shrink-0 text-[11px] text-slate-400 transition-transform"
+                :class="{ 'rotate-180': isFilterOpen }"
+              ></i>
+            </button>
+
+            <div
+              v-if="isFilterOpen"
+              class="absolute top-full right-0 z-20 mt-3 w-[280px] rounded-[24px] border border-slate-200 bg-white p-3 shadow-[0_20px_50px_rgba(15,23,42,0.12)]"
+            >
+              <div class="mb-3 flex items-center justify-between px-2">
+                <strong class="text-sm font-bold text-slate-900">
+                  카테고리 선택
+                </strong>
+                <button
+                  type="button"
+                  class="text-xs font-medium text-slate-400 transition hover:text-slate-600"
+                  @click="isFilterOpen = false"
+                >
+                  닫기
+                </button>
+              </div>
+
+              <div class="max-h-[320px] space-y-2 overflow-y-auto pr-1">
+                <button
+                  type="button"
+                  class="flex w-full items-center justify-between rounded-[18px] px-4 py-3 text-left text-sm font-semibold transition"
+                  :class="
+                    !hasActiveCategory
+                      ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                      : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
+                  "
+                  @click="clearCategoryFilter"
+                >
+                  <span class="flex items-center gap-3">
+                    <i class="fa-solid fa-layer-group text-emerald-500"></i>
+                    전체 보기
+                  </span>
+                  <i
+                    v-if="!hasActiveCategory"
+                    class="fa-solid fa-check text-xs text-emerald-500"
+                  ></i>
+                </button>
+
+                <button
+                  v-for="option in filterOptions"
+                  :key="option.value"
+                  type="button"
+                  class="flex w-full items-center justify-between rounded-[18px] px-4 py-3 text-left text-sm font-semibold transition"
+                  :class="
+                    selectedCategories.includes(option.value)
+                      ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
+                      : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
+                  "
+                  @click="toggleCategoryFilter(option.value)"
+                >
+                  <span class="flex items-center gap-3">
+                    <i :class="[option.icon, option.iconClass]"></i>
+                    {{ option.label }}
+                  </span>
+                  <i
+                    v-if="selectedCategories.includes(option.value)"
+                    class="fa-solid fa-check text-xs text-emerald-500"
+                  ></i>
+                </button>
+
+                <p
+                  v-if="filterOptions.length === 0"
+                  class="rounded-[18px] bg-slate-50 px-4 py-5 text-center text-sm text-slate-400"
+                >
+                  선택한 기간에 해당하는 카테고리가 없어요.
+                </p>
+              </div>
+
+
+            </div>
+          </div>
+        </div>
 
         <div
-          v-if="isFilterOpen"
-          class="absolute top-full right-0 z-20 mt-3 w-[280px] rounded-[24px] border border-slate-200 bg-white p-3 shadow-[0_20px_50px_rgba(15,23,42,0.12)]"
+          v-if="hasActiveRange || hasActiveCategory"
+          class="flex flex-wrap items-center gap-2 px-1"
         >
-          <div class="mb-3 flex items-center justify-between px-2">
-            <strong class="text-sm font-bold text-slate-900">
-              카테고리 선택
-            </strong>
-            <button
-              type="button"
-              class="text-xs font-medium text-slate-400 transition hover:text-slate-600"
-              @click="isFilterOpen = false"
-            >
-              닫기
-            </button>
-          </div>
+          <button
+            v-if="hasActiveRange"
+            type="button"
+            class="inline-flex max-w-full items-center gap-2 rounded-full bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-700 ring-1 ring-emerald-200 transition hover:bg-emerald-100"
+            @click="clearDateRange"
+          >
+            <i class="fa-solid fa-calendar-days shrink-0 text-[11px]"></i>
+            <span class="truncate">{{ rangeLabel }}</span>
+            <i class="fa-solid fa-xmark shrink-0 text-[11px]"></i>
+          </button>
 
-          <div class="max-h-[320px] space-y-2 overflow-y-auto pr-1">
-            <button
-              type="button"
-              class="flex w-full items-center justify-between rounded-[18px] px-4 py-3 text-left text-sm font-semibold transition"
-              :class="
-                !selectedCategory
-                  ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
-                  : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-              "
-              @click="clearCategoryFilter"
-            >
-              <span class="flex items-center gap-3">
-                <i class="fa-solid fa-layer-group text-emerald-500"></i>
-                전체 보기
-              </span>
-              <i
-                v-if="!selectedCategory"
-                class="fa-solid fa-check text-xs text-emerald-500"
-              ></i>
-            </button>
-
-            <button
-              v-for="option in filterOptions"
-              :key="option.value"
-              type="button"
-              class="flex w-full items-center justify-between rounded-[18px] px-4 py-3 text-left text-sm font-semibold transition"
-              :class="
-                selectedCategory === option.value
-                  ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200'
-                  : 'bg-slate-50 text-slate-600 hover:bg-slate-100'
-              "
-              @click="applyCategoryFilter(option.value)"
-            >
-              <span class="flex items-center gap-3">
-                <i :class="[option.icon, option.iconClass]"></i>
-                {{ option.label }}
-              </span>
-              <i
-                v-if="selectedCategory === option.value"
-                class="fa-solid fa-check text-xs text-emerald-500"
-              ></i>
-            </button>
-
-            <p
-              v-if="filterOptions.length === 0"
-              class="rounded-[18px] bg-slate-50 px-4 py-5 text-center text-sm text-slate-400"
-            >
-              아직 선택할 수 있는 카테고리가 없어요.
-            </p>
-          </div>
+          <button
+            v-for="category in selectedCategoryChips"
+            :key="category.value"
+            type="button"
+            class="inline-flex max-w-full items-center gap-2 rounded-full bg-white px-3 py-2 text-xs font-semibold text-slate-600 ring-1 ring-slate-200 transition hover:bg-slate-50"
+            @click="removeCategoryFilter(category.value)"
+          >
+            <i :class="[category.icon, category.iconClass, 'shrink-0 text-[11px]']"></i>
+            <span class="truncate">{{ category.label }}</span>
+            <i class="fa-solid fa-xmark shrink-0 text-[11px]"></i>
+          </button>
         </div>
       </section>
 
@@ -326,3 +671,7 @@ watch(
 </template>
 
 <style scoped></style>
+
+
+
+

--- a/front/src/stores/momo.js
+++ b/front/src/stores/momo.js
@@ -96,18 +96,28 @@ export const useMomoStore = defineStore('momo', () => {
     }
   };
 
-  const fetchTransactionList = async (userId) => {
+  const fetchTransactionList = async (userId, filters = {}) => {
     isFetching.value = true;
     isError.value = false;
 
     try {
+      const params = {
+        userId,
+      };
+
+      if (filters.category) {
+        params.category = filters.category;
+      }
+
       const response = await axios.get(`${BASE_URL}/transactions`, {
-        params: { userId },
+        params,
       });
       transactionList.value = response.data;
+      return response.data;
     } catch (error) {
       console.error('fetchTransactionList error:', error);
       isError.value = true;
+      return [];
     } finally {
       isFetching.value = false;
     }


### PR DESCRIPTION
## 변경 내용
- 전체 목록 페이지에 카테고리 필터 기능 추가
- 우측 상단 필터 버튼 클릭 시 현재까지 입력된 카테고리 목록이 팝오버 형태로 노출되도록 구현
- 카테고리 선택 시 해당 카테고리 거래 내역만 조회되도록 반영
- 필터 해제 시 전체 거래 내역이 다시 조회되도록 처리
- 필터 선택 상태에 따라 안내 문구가 동적으로 변경되도록 반영

## 화면 비교

| point | Before | After |
| --- | --- | --- |
| 모바일 |<img width="315" height="694" alt="모바일 필터 반영 전" src="https://github.com/user-attachments/assets/fe3da7b6-7a2c-4c69-bfe4-f5c2cab85b9d" /> | <img width="321" height="694" alt="모바일 필터 반영 후" src="https://github.com/user-attachments/assets/d37d09e2-1229-4282-a18d-4a6c1bf444fb" />|
| 데스크탑 | <img width="1305" height="898" alt="데스크탑 필터 반영 전" src="https://github.com/user-attachments/assets/43f74b5d-a7f2-41eb-baca-779dac5c666f" />|<img width="1304" height="895" alt="데스크탑 필터 반영 후" src="https://github.com/user-attachments/assets/b215851c-a358-41ef-84db-7000e22be60e" /> |

| point | 필터적용 |
| --- | --- |
| 모바일 | <img width="321" height="695" alt="모바일 필터 적용" src="https://github.com/user-attachments/assets/5bb3edac-eb58-4db9-9adc-31495737dcf5" /> |  
| 데스크탑|<img width="1304" height="891" alt="데스크톱 필터 적용" src="https://github.com/user-attachments/assets/b572c7bf-e0b5-45fa-8b89-919e749a969b" /> | 

## 확인 포인트
- 필터 버튼이 전체 목록 페이지 우측 상단에 정상적으로 노출되는지
- 현재까지 입력된 카테고리만 필터 선택지로 보이는지
- 카테고리 선택 시 해당 카테고리 거래 내역만 조회되는지
- 필터 해제 시 전체 거래 내역으로 복원되는지
- 안내 문구가 선택 상태에 따라 아래처럼 변경되는지
- 기본: `전체 거래 내역을 날짜별로 확인할 수 있어요`
- 필터 선택 시: `카테고리 내역을 날짜별로 확인할 수 있어요`
